### PR TITLE
Change #footer .social to be white and not the same grey as the background

### DIFF
--- a/static/css/style.default.css
+++ b/static/css/style.default.css
@@ -2593,7 +2593,7 @@ fieldset[disabled] .btn-template-primary.active {
   margin-bottom: 0;
 }
 #footer .social a {
-  color: #555555;
+  color: #ffffff;
   font-size: 25px;
   margin: 0 10px 0 0;
 }


### PR DESCRIPTION
Currently if the `social` section of the `top.html` is moved to the bottom, it will be effect by this setting by default, which will make the icons visible only on hover as the non-hover setting is the same as the background they are placed on.